### PR TITLE
Fix when trade request return an empty array

### DIFF
--- a/js/station-haul.js
+++ b/js/station-haul.js
@@ -221,6 +221,8 @@ Route.prototype.executeOrders = function() {
                 this.itemIds.push(itemId);
         }
 
+        if (this.itemIds.length === 0) this.completed = true;
+
         this.calculate();
     }
 };


### PR DESCRIPTION
Was testing a station this evening, the region response an empty array.
Same behaviour directly on ESI so, not a mistake.
https://esi.evetech.net/latest/markets/10000019/orders/?datasource=tranquility&order_type=all&page=1 (old region not connected to any other regions).