### PR TITLE
Refactor: Move TradingTable inline styles to external CSS file

### DIFF
--- a/src/components/common/SecurityBadge.jsx
+++ b/src/components/common/SecurityBadge.jsx
@@ -1,0 +1,69 @@
+import PropTypes from 'prop-types';
+import { getSecurityLevel, formatSecurityStatus } from '../../utils/security';
+import { SECURITY_COLORS } from '../../utils/constants';
+
+/**
+ * Security Badge Component
+ * Displays security status with EVE-accurate coloring
+ */
+export function SecurityBadge({
+  security,
+  isCitadel = false,
+  showLabel = true,
+  size = 'sm',
+}) {
+  const level = getSecurityLevel(security);
+  const colors = SECURITY_COLORS[level] || SECURITY_COLORS[0];
+
+  const sizeClasses = {
+    xs: 'px-1.5 py-0.5 text-[10px]',
+    sm: 'px-2 py-0.5 text-xs',
+    md: 'px-2.5 py-1 text-sm',
+    lg: 'px-3 py-1.5 text-base',
+  };
+
+  return (
+    <span
+      className={`
+        inline-flex items-center gap-1
+        ${sizeClasses[size]}
+        rounded-full font-mono font-medium
+        ${colors.bg} text-space-black
+        ${isCitadel ? 'ring-2 ring-accent-gold ring-offset-1 ring-offset-space-dark dark:ring-offset-space-dark ring-offset-white' : ''}
+      `}
+      title={`Security: ${formatSecurityStatus(security)}${isCitadel ? ' (Player Structure)' : ''}`}
+    >
+      {showLabel && formatSecurityStatus(security)}
+      {isCitadel && <span className="text-[10px]">★</span>}
+    </span>
+  );
+}
+
+SecurityBadge.propTypes = {
+  security: PropTypes.number.isRequired,
+  isCitadel: PropTypes.bool,
+  showLabel: PropTypes.bool,
+  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg']),
+};
+
+/**
+ * Inline Security Text
+ * For use in tables or inline content
+ */
+export function SecurityText({ security, className = '' }) {
+  const level = getSecurityLevel(security);
+  const colors = SECURITY_COLORS[level] || SECURITY_COLORS[0];
+
+  return (
+    <span className={`font-mono ${colors.text} ${className}`}>
+      {formatSecurityStatus(security)}
+    </span>
+  );
+}
+
+SecurityText.propTypes = {
+  security: PropTypes.number.isRequired,
+  className: PropTypes.string,
+};
+
+export default SecurityBadge;

--- a/src/components/common/SkeletonLoader.jsx
+++ b/src/components/common/SkeletonLoader.jsx
@@ -1,0 +1,112 @@
+import PropTypes from 'prop-types';
+
+/**
+ * Skeleton Loader Component
+ * Placeholder loading animation for content
+ */
+export function Skeleton({ className = '', variant = 'text' }) {
+  const baseClasses = 'animate-pulse bg-space-mid/50 dark:bg-space-mid/50 bg-gray-200 rounded';
+
+  const variantClasses = {
+    text: 'h-4 w-full',
+    title: 'h-6 w-3/4',
+    avatar: 'h-10 w-10 rounded-full',
+    button: 'h-10 w-24',
+    card: 'h-32 w-full',
+    table: 'h-12 w-full',
+  };
+
+  return (
+    <div className={`${baseClasses} ${variantClasses[variant]} ${className}`} />
+  );
+}
+
+Skeleton.propTypes = {
+  className: PropTypes.string,
+  variant: PropTypes.oneOf(['text', 'title', 'avatar', 'button', 'card', 'table']),
+};
+
+/**
+ * Skeleton Table Rows
+ */
+export function SkeletonTable({ rows = 5, columns = 6 }) {
+  return (
+    <div className="space-y-2">
+      {/* Header */}
+      <div className="flex gap-4 py-3 border-b border-accent-cyan/10">
+        {Array.from({ length: columns }).map((_, i) => (
+          <Skeleton key={i} className="h-4 flex-1" />
+        ))}
+      </div>
+
+      {/* Rows */}
+      {Array.from({ length: rows }).map((_, rowIndex) => (
+        <div key={rowIndex} className="flex gap-4 py-3">
+          {Array.from({ length: columns }).map((_, colIndex) => (
+            <Skeleton
+              key={colIndex}
+              className={`h-4 flex-1 ${colIndex === 0 ? 'w-32' : ''}`}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+SkeletonTable.propTypes = {
+  rows: PropTypes.number,
+  columns: PropTypes.number,
+};
+
+/**
+ * Skeleton Card
+ */
+export function SkeletonCard() {
+  return (
+    <div className="glass p-6 space-y-4">
+      <Skeleton variant="title" />
+      <Skeleton variant="text" />
+      <Skeleton variant="text" className="w-2/3" />
+      <div className="flex gap-2 pt-2">
+        <Skeleton variant="button" />
+        <Skeleton variant="button" />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Full page skeleton loader
+ */
+export function SkeletonPage() {
+  return (
+    <div className="max-w-7xl mx-auto px-4 py-8 space-y-8">
+      {/* Header */}
+      <div className="space-y-2">
+        <Skeleton variant="title" className="w-48" />
+        <Skeleton variant="text" className="w-96" />
+      </div>
+
+      {/* Form skeleton */}
+      <div className="glass p-6">
+        <div className="grid md:grid-cols-3 gap-6">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="space-y-2">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-12 w-full" />
+            </div>
+          ))}
+        </div>
+        <Skeleton variant="button" className="mt-6 w-full h-12" />
+      </div>
+
+      {/* Table skeleton */}
+      <div className="glass p-6">
+        <SkeletonTable rows={8} columns={7} />
+      </div>
+    </div>
+  );
+}
+
+export default Skeleton;

--- a/src/components/tables/TradingTable.css
+++ b/src/components/tables/TradingTable.css
@@ -1,0 +1,186 @@
+/* Trading Table Styles */
+
+.trading-table-wrapper {
+  background: rgba(26, 26, 46, 0.3);
+  border-radius: 0.75rem;
+  border: 1px solid rgba(0, 212, 255, 0.1);
+  overflow: hidden;
+}
+
+.dt-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  gap: 1rem;
+  flex-wrap: wrap;
+  background: rgba(22, 33, 62, 0.5);
+  border-bottom: 1px solid rgba(0, 212, 255, 0.1);
+}
+
+.dt-bottom {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  gap: 1rem;
+  flex-wrap: wrap;
+  background: rgba(22, 33, 62, 0.3);
+  border-top: 1px solid rgba(0, 212, 255, 0.1);
+}
+
+.dt-controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.dt-search input {
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  background: rgba(10, 10, 15, 0.5);
+  border: 1px solid rgba(0, 212, 255, 0.2);
+  color: #e2e8f0;
+  font-size: 0.875rem;
+  min-width: 200px;
+}
+
+.dt-search input:focus {
+  outline: none;
+  border-color: #00d4ff;
+  box-shadow: 0 0 0 1px #00d4ff;
+}
+
+.dt-buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.dt-button {
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  background: rgba(0, 212, 255, 0.1);
+  border: 1px solid rgba(0, 212, 255, 0.3);
+  color: #00d4ff;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.dt-button:hover {
+  background: rgba(0, 212, 255, 0.2);
+  border-color: rgba(0, 212, 255, 0.5);
+}
+
+.table-scroll-wrapper {
+  overflow-x: auto;
+}
+
+table.trading-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+table.trading-table thead th {
+  background: rgba(22, 33, 62, 0.8);
+  color: #00d4ff;
+  font-family: 'Orbitron', sans-serif;
+  font-weight: 600;
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(0, 212, 255, 0.2);
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+}
+
+table.trading-table thead th:hover {
+  background: rgba(22, 33, 62, 1);
+}
+
+table.trading-table thead th .sort-indicator {
+  color: #ffd700;
+}
+
+table.trading-table tbody td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgba(0, 212, 255, 0.05);
+  color: #e2e8f0;
+}
+
+table.trading-table tbody tr:hover td {
+  background: rgba(0, 212, 255, 0.05);
+}
+
+table.trading-table tbody tr.clickable {
+  cursor: pointer;
+}
+
+.dt-info {
+  color: #94a3b8;
+  font-size: 0.875rem;
+}
+
+.dt-length {
+  color: #94a3b8;
+  font-size: 0.875rem;
+}
+
+.dt-length select {
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  background: rgba(10, 10, 15, 0.5);
+  border: 1px solid rgba(0, 212, 255, 0.2);
+  color: #e2e8f0;
+  margin: 0 0.25rem;
+}
+
+.dt-paging {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.dt-paging button {
+  padding: 0.25rem 0.75rem;
+  border-radius: 0.25rem;
+  background: rgba(0, 212, 255, 0.1);
+  border: 1px solid rgba(0, 212, 255, 0.2);
+  color: #00d4ff;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.dt-paging button:hover:not(:disabled) {
+  background: rgba(0, 212, 255, 0.2);
+}
+
+.dt-paging button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.page-info {
+  color: #94a3b8;
+  font-size: 0.875rem;
+  padding: 0 0.5rem;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .dt-top,
+  .dt-bottom {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .dt-search input {
+    width: 100%;
+  }
+
+  .dt-controls {
+    justify-content: space-between;
+  }
+}

--- a/src/components/tables/TradingTable.jsx
+++ b/src/components/tables/TradingTable.jsx
@@ -1,0 +1,274 @@
+import { useState, useMemo, useCallback } from 'react';
+import './TradingTable.css';
+
+/**
+ * Trading Table Component
+ * Custom React table with sorting, pagination, and search
+ */
+export function TradingTable({
+  data = [],
+  columns = [],
+  onRowClick,
+  defaultSort = null,
+  pageLength = 25,
+  className = '',
+  emptyMessage = 'No data available',
+}) {
+  // Pagination state
+  const [currentPage, setCurrentPage] = useState(0);
+  const [itemsPerPage, setItemsPerPage] = useState(pageLength);
+
+  // Search state
+  const [searchTerm, setSearchTerm] = useState('');
+
+  // Sort state
+  const [sortConfig, setSortConfig] = useState(() => {
+    if (defaultSort) {
+      return { key: defaultSort.column, direction: defaultSort.direction };
+    }
+    const defaultCol = columns.find(c => c.defaultSort);
+    return defaultCol ? { key: defaultCol.key, direction: 'desc' } : null;
+  });
+
+  // Filter data by search term
+  const filteredData = useMemo(() => {
+    if (!searchTerm.trim()) return data;
+    const term = searchTerm.toLowerCase();
+    return data.filter(row =>
+      columns.some(col => {
+        const value = row[col.key];
+        if (value == null) return false;
+        return String(value).toLowerCase().includes(term);
+      })
+    );
+  }, [data, searchTerm, columns]);
+
+  // Sort data
+  const sortedData = useMemo(() => {
+    if (!sortConfig) return filteredData;
+
+    return [...filteredData].sort((a, b) => {
+      const aVal = a[sortConfig.key];
+      const bVal = b[sortConfig.key];
+
+      // Handle null/undefined
+      if (aVal == null && bVal == null) return 0;
+      if (aVal == null) return 1;
+      if (bVal == null) return -1;
+
+      // Numeric comparison
+      const col = columns.find(c => c.key === sortConfig.key);
+      if (col?.type === 'num' || typeof aVal === 'number') {
+        const diff = Number(aVal) - Number(bVal);
+        return sortConfig.direction === 'asc' ? diff : -diff;
+      }
+
+      // String comparison
+      const comparison = String(aVal).localeCompare(String(bVal));
+      return sortConfig.direction === 'asc' ? comparison : -comparison;
+    });
+  }, [filteredData, sortConfig, columns]);
+
+  // Paginate data
+  const paginatedData = useMemo(() => {
+    const start = currentPage * itemsPerPage;
+    return sortedData.slice(start, start + itemsPerPage);
+  }, [sortedData, currentPage, itemsPerPage]);
+
+  // Total pages
+  const totalPages = Math.ceil(sortedData.length / itemsPerPage);
+
+  // Handle sort click
+  const handleSort = useCallback((key) => {
+    setSortConfig(prev => {
+      if (prev?.key === key) {
+        return { key, direction: prev.direction === 'asc' ? 'desc' : 'asc' };
+      }
+      return { key, direction: 'desc' };
+    });
+    setCurrentPage(0);
+  }, []);
+
+  // Handle page change
+  const goToPage = useCallback((page) => {
+    setCurrentPage(Math.max(0, Math.min(page, totalPages - 1)));
+  }, [totalPages]);
+
+  // Export to CSV
+  const exportCSV = useCallback(() => {
+    const headers = columns.map(c => c.label).join(',');
+    const rows = sortedData.map(row =>
+      columns.map(col => {
+        const val = row[col.key];
+        // Escape quotes and wrap in quotes if contains comma
+        const str = String(val ?? '');
+        return str.includes(',') || str.includes('"')
+          ? `"${str.replace(/"/g, '""')}"`
+          : str;
+      }).join(',')
+    );
+    const csv = [headers, ...rows].join('\n');
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'trading-data.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [sortedData, columns]);
+
+  // Copy to clipboard
+  const copyToClipboard = useCallback(() => {
+    const headers = columns.map(c => c.label).join('\t');
+    const rows = sortedData.map(row =>
+      columns.map(col => String(row[col.key] ?? '')).join('\t')
+    );
+    const text = [headers, ...rows].join('\n');
+    navigator.clipboard.writeText(text);
+  }, [sortedData, columns]);
+
+  // Render cell value
+  const renderCell = useCallback((row, col) => {
+    const value = row[col.key];
+    if (col.render) {
+      return col.render(value, row);
+    }
+    return value ?? '';
+  }, []);
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="trading-table-wrapper">
+        <div className="text-center py-12 text-text-secondary">
+          {emptyMessage}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`trading-table-wrapper ${className}`}>
+      {/* Top Controls */}
+      <div className="dt-top">
+        <div className="dt-buttons">
+          <button type="button" onClick={copyToClipboard} className="dt-button">
+            Copy
+          </button>
+          <button type="button" onClick={exportCSV} className="dt-button">
+            CSV
+          </button>
+        </div>
+        <div className="dt-search">
+          <input
+            type="text"
+            placeholder="Search results..."
+            value={searchTerm}
+            onChange={(e) => {
+              setSearchTerm(e.target.value);
+              setCurrentPage(0);
+            }}
+          />
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="table-scroll-wrapper">
+        <table className="trading-table">
+          <thead>
+            <tr>
+              {columns.filter(c => c.visible !== false).map(col => (
+                <th
+                  key={col.key}
+                  onClick={() => handleSort(col.key)}
+                  className={`sortable ${sortConfig?.key === col.key ? `sorting_${sortConfig.direction}` : ''}`}
+                >
+                  {col.label}
+                  {sortConfig?.key === col.key && (
+                    <span className="sort-indicator">
+                      {sortConfig.direction === 'asc' ? ' ↑' : ' ↓'}
+                    </span>
+                  )}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {paginatedData.map((row, idx) => (
+              <tr
+                key={row['Item ID'] || idx}
+                onClick={() => onRowClick?.(row, idx)}
+                className={onRowClick ? 'clickable' : ''}
+              >
+                {columns.filter(c => c.visible !== false).map(col => (
+                  <td key={col.key} className={col.className || ''}>
+                    {renderCell(row, col)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Bottom Controls */}
+      <div className="dt-bottom">
+        <div className="dt-info">
+          Showing {currentPage * itemsPerPage + 1} to {Math.min((currentPage + 1) * itemsPerPage, sortedData.length)} of {sortedData.length} entries
+          {searchTerm && ` (filtered from ${data.length} total)`}
+        </div>
+        <div className="dt-controls">
+          <label className="dt-length">
+            Show{' '}
+            <select
+              value={itemsPerPage}
+              onChange={(e) => {
+                setItemsPerPage(Number(e.target.value));
+                setCurrentPage(0);
+              }}
+            >
+              <option value={10}>10</option>
+              <option value={25}>25</option>
+              <option value={50}>50</option>
+              <option value={100}>100</option>
+            </select>
+          </label>
+          <div className="dt-paging">
+            <button
+              type="button"
+              onClick={() => goToPage(0)}
+              disabled={currentPage === 0}
+            >
+              «
+            </button>
+            <button
+              type="button"
+              onClick={() => goToPage(currentPage - 1)}
+              disabled={currentPage === 0}
+            >
+              ‹
+            </button>
+            <span className="page-info">
+              Page {currentPage + 1} of {totalPages}
+            </span>
+            <button
+              type="button"
+              onClick={() => goToPage(currentPage + 1)}
+              disabled={currentPage >= totalPages - 1}
+            >
+              ›
+            </button>
+            <button
+              type="button"
+              onClick={() => goToPage(totalPages - 1)}
+              disabled={currentPage >= totalPages - 1}
+            >
+              »
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default TradingTable;

--- a/src/hooks/useCache.js
+++ b/src/hooks/useCache.js
@@ -1,0 +1,300 @@
+import { CACHE_CONFIG } from '../utils/constants';
+
+const { dbName, storeName, duration } = CACHE_CONFIG;
+
+// Cache key prefix for consistent identification
+const CACHE_KEY_PREFIX = 'evetrade_cache_';
+const CACHE_REGISTRY_KEY = 'evetrade_cache_registry';
+
+/**
+ * Get the full cache key with prefix
+ * @param {string} key - Original cache key
+ * @returns {string} Prefixed cache key
+ */
+function getCacheKey(key) {
+  return `${CACHE_KEY_PREFIX}${key}`;
+}
+
+/**
+ * Get the timestamp key for a cache entry
+ * @param {string} key - Original cache key
+ * @returns {string} Timestamp key
+ */
+function getTimestampKey(key) {
+  return `${CACHE_KEY_PREFIX}${key}_timestamp`;
+}
+
+/**
+ * Get the cache registry (list of all cached keys)
+ * @returns {Set<string>} Set of cached keys
+ */
+function getCacheRegistry() {
+  try {
+    const registry = localStorage.getItem(CACHE_REGISTRY_KEY);
+    return registry ? new Set(JSON.parse(registry)) : new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+/**
+ * Update the cache registry
+ * @param {Set<string>} registry - Updated registry
+ */
+function updateCacheRegistry(registry) {
+  try {
+    localStorage.setItem(CACHE_REGISTRY_KEY, JSON.stringify([...registry]));
+  } catch (error) {
+    console.warn('Failed to update cache registry:', error);
+  }
+}
+
+/**
+ * Add a key to the cache registry
+ * @param {string} key - Cache key to register
+ */
+function registerCacheKey(key) {
+  const registry = getCacheRegistry();
+  registry.add(key);
+  updateCacheRegistry(registry);
+}
+
+/**
+ * Remove a key from the cache registry
+ * @param {string} key - Cache key to unregister
+ */
+function unregisterCacheKey(key) {
+  const registry = getCacheRegistry();
+  registry.delete(key);
+  updateCacheRegistry(registry);
+}
+
+/**
+ * Open IndexedDB database
+ * @returns {Promise<IDBDatabase>}
+ */
+async function openDB() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(dbName, 1);
+
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve(request.result);
+
+    request.onupgradeneeded = (event) => {
+      const db = event.target.result;
+      if (!db.objectStoreNames.contains(storeName)) {
+        db.createObjectStore(storeName, { keyPath: 'key' });
+      }
+    };
+  });
+}
+
+/**
+ * Get cached data from localStorage or IndexedDB
+ * @param {string} key - Cache key
+ * @returns {Promise<any|null>} Cached data or null if not found/expired
+ */
+export async function getCached(key) {
+  const cacheKey = getCacheKey(key);
+  const timestampKey = getTimestampKey(key);
+
+  try {
+    // Try localStorage first (faster, for smaller items)
+    const localData = localStorage.getItem(cacheKey);
+    const localTimestamp = localStorage.getItem(timestampKey);
+
+    if (localData && localTimestamp) {
+      const timestamp = parseInt(localTimestamp, 10);
+      if (Date.now() - timestamp < duration) {
+        try {
+          return JSON.parse(localData);
+        } catch {
+          // Invalid JSON, clear it
+          localStorage.removeItem(cacheKey);
+          localStorage.removeItem(timestampKey);
+          unregisterCacheKey(key);
+        }
+      } else {
+        // Expired, clean up
+        localStorage.removeItem(cacheKey);
+        localStorage.removeItem(timestampKey);
+        unregisterCacheKey(key);
+      }
+    }
+
+    // Fall back to IndexedDB (for larger items)
+    const db = await openDB();
+    const tx = db.transaction(storeName, 'readonly');
+    const store = tx.objectStore(storeName);
+
+    return new Promise((resolve) => {
+      const request = store.get(cacheKey);
+
+      request.onerror = () => {
+        console.warn('IndexedDB read error:', request.error);
+        resolve(null);
+      };
+
+      request.onsuccess = () => {
+        const result = request.result;
+        if (result && Date.now() - result.timestamp < duration) {
+          resolve(result.data);
+        } else {
+          resolve(null);
+        }
+      };
+    });
+  } catch (error) {
+    console.warn('Cache read error:', error);
+    return null;
+  }
+}
+
+/**
+ * Set cached data in localStorage or IndexedDB
+ * @param {string} key - Cache key
+ * @param {any} data - Data to cache
+ */
+export async function setCached(key, data) {
+  const cacheKey = getCacheKey(key);
+  const timestampKey = getTimestampKey(key);
+  const timestamp = Date.now();
+
+  try {
+    // Try localStorage first (for items < 2MB)
+    const serialized = JSON.stringify(data);
+
+    if (serialized.length < 2 * 1024 * 1024) {
+      try {
+        localStorage.setItem(cacheKey, serialized);
+        localStorage.setItem(timestampKey, timestamp.toString());
+        registerCacheKey(key);
+        return;
+      } catch (e) {
+        // localStorage full or quota exceeded, fall through to IndexedDB
+        console.warn('localStorage full, using IndexedDB');
+      }
+    }
+
+    // Use IndexedDB for larger items
+    const db = await openDB();
+    const tx = db.transaction(storeName, 'readwrite');
+    const store = tx.objectStore(storeName);
+
+    await new Promise((resolve, reject) => {
+      const request = store.put({ key: cacheKey, data, timestamp });
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => resolve();
+    });
+
+    registerCacheKey(key);
+  } catch (error) {
+    console.warn('Cache write error:', error);
+  }
+}
+
+/**
+ * Clear specific cache key
+ * @param {string} key - Cache key to clear
+ */
+export async function clearCached(key) {
+  const cacheKey = getCacheKey(key);
+  const timestampKey = getTimestampKey(key);
+
+  try {
+    // Clear from localStorage
+    localStorage.removeItem(cacheKey);
+    localStorage.removeItem(timestampKey);
+
+    // Clear from IndexedDB
+    const db = await openDB();
+    const tx = db.transaction(storeName, 'readwrite');
+    const store = tx.objectStore(storeName);
+    store.delete(cacheKey);
+
+    // Remove from registry
+    unregisterCacheKey(key);
+  } catch (error) {
+    console.warn('Cache clear error:', error);
+  }
+}
+
+/**
+ * Clear all cached data
+ */
+export async function clearAllCache() {
+  try {
+    // Get all registered cache keys
+    const registry = getCacheRegistry();
+
+    // Clear each registered key from localStorage
+    registry.forEach((key) => {
+      const cacheKey = getCacheKey(key);
+      const timestampKey = getTimestampKey(key);
+      localStorage.removeItem(cacheKey);
+      localStorage.removeItem(timestampKey);
+    });
+
+    // Also clear any orphaned keys with our prefix (fallback cleanup)
+    const keysToRemove = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith(CACHE_KEY_PREFIX) && key !== CACHE_REGISTRY_KEY) {
+        keysToRemove.push(key);
+      }
+    }
+    keysToRemove.forEach((key) => localStorage.removeItem(key));
+
+    // Clear the registry itself
+    localStorage.removeItem(CACHE_REGISTRY_KEY);
+
+    // Clear IndexedDB
+    const db = await openDB();
+    const tx = db.transaction(storeName, 'readwrite');
+    const store = tx.objectStore(storeName);
+    store.clear();
+  } catch (error) {
+    console.warn('Cache clear all error:', error);
+  }
+}
+
+/**
+ * Get cache statistics
+ * @returns {Promise<object>} Cache stats
+ */
+export async function getCacheStats() {
+  const stats = {
+    localStorageItems: 0,
+    localStorageSize: 0,
+    indexedDBItems: 0,
+  };
+
+  try {
+    // Count localStorage items with our prefix
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith(CACHE_KEY_PREFIX)) {
+        stats.localStorageItems++;
+        stats.localStorageSize += (localStorage.getItem(key) || '').length;
+      }
+    }
+
+    // Count IndexedDB items
+    const db = await openDB();
+    const tx = db.transaction(storeName, 'readonly');
+    const store = tx.objectStore(storeName);
+
+    await new Promise((resolve) => {
+      const request = store.count();
+      request.onsuccess = () => {
+        stats.indexedDBItems = request.result;
+        resolve();
+      };
+      request.onerror = () => resolve();
+    });
+  } catch (error) {
+    console.warn('Cache stats error:', error);
+  }
+
+  return stats;
+}

--- a/src/hooks/useDebounce.js
+++ b/src/hooks/useDebounce.js
@@ -1,0 +1,37 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Custom hook that debounces a value
+ *
+ * @param {any} value - The value to debounce
+ * @param {number} delay - The delay in milliseconds (default: 500)
+ * @returns {any} The debounced value
+ *
+ * @example
+ * const [searchInput, setSearchInput] = useState('');
+ * const debouncedSearch = useDebounce(searchInput, 300);
+ *
+ * // Use debouncedSearch for expensive operations
+ * useEffect(() => {
+ *   performSearch(debouncedSearch);
+ * }, [debouncedSearch]);
+ */
+export function useDebounce(value, delay = 500) {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    // Set up the timeout
+    const timeoutId = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    // Clean up the timeout if value changes before delay expires
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+export default useDebounce;


### PR DESCRIPTION
## Summary
- Extracted 186-line inline `<style>` block from TradingTable.jsx (lines 270-455) into dedicated CSS file
- Created `src/components/tables/TradingTable.css` with all table styles
- Added CSS import to TradingTable.jsx component
- No functional changes - styling remains identical

## Benefits
- Improved code maintainability and separation of concerns
- Easier to modify and manage styles independently
- Cleaner JSX component file
- Follows best practices for React component styling

## Test plan
- [ ] Verify all trading pages render correctly (Station Trading, Station Hauling, Region Hauling)
- [ ] Check table styling matches previous appearance
- [ ] Test sorting functionality
- [ ] Test pagination controls
- [ ] Test search/filter functionality
- [ ] Test CSV export and copy buttons
- [ ] Verify responsive design on mobile viewports
- [ ] Check hover states and animations

Generated with [Claude Code](https://claude.com/claude-code)